### PR TITLE
added pygame dependency and updated tensorflow requirement to 1.13.0rc1 to support python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp==3.5.4
 numpy==1.16.1
 keras==2.2.4
-tensorflow==1.12.0
+tensorflow==1.13.0rc1
 gunicorn==19.9.0
 aiohttp-cors==0.7.0
+pygame


### PR DESCRIPTION
Olá Daniel
Conversamos hoje pelo zoom a respeito de microserviços e acabei encontrando seu GitHub e achei muito bacana esse projeto!

Tentei rodar no python 3.7 mas não consegui a dependência do `tensorflow==1.12.0` e faltava o pygame mas fiz essas mudanças e rodou no 3.5.6, 3.6.0 e 3.7.0. Agora vou estudar isso aí 🚀